### PR TITLE
[style] Override certain theme layouts and styles

### DIFF
--- a/assets/scss/hyde-hyde/_list.scss
+++ b/assets/scss/hyde-hyde/_list.scss
@@ -1,0 +1,27 @@
+// for the list of posts
+
+.section__title {
+	font-size: $section__title-font-size;
+}
+
+.post-list__item {
+	margin-bottom: 1.25em;
+}
+
+.item__title--big {
+	display: block;
+	font-size: $item__title-big-font-size;
+	line-height: 1.25;
+}
+
+.item__title--small {
+	font-size: 1rem;
+}
+
+.item__date {
+	color: $item__date-color;
+	display: block;
+	font-size: $item__date-font-size;
+	margin-bottom: .2rem;
+	margin-top: .2rem;
+}

--- a/assets/scss/hyde-hyde/_list.scss
+++ b/assets/scss/hyde-hyde/_list.scss
@@ -5,7 +5,7 @@
 }
 
 .post-list__item {
-	margin-bottom: 1.25em;
+	margin-bottom: 1em;
 }
 
 .item__title--big {

--- a/assets/scss/hyde-hyde/_variables.scss
+++ b/assets/scss/hyde-hyde/_variables.scss
@@ -1,0 +1,112 @@
+$gray-0: #fafafa;
+$gray-1: #f9f9f9;
+$gray-2: #eee;
+$gray-3: #ddd;
+$gray-4: #ccc;
+$gray-5: #bbb;
+$gray-6: #878787;
+$gray-7: #767676;
+$gray-8: #515151;
+$gray-9: #313131;
+
+$white: #fff;
+$red: #ac4142;
+$orange: #d28445;
+$yellow: #f4bf75;
+$green: #90a959;
+$cyan: #75b5aa;
+$blue: #268bd2;
+$brown: #8f5536;
+
+//https://www.client9.com/css-system-font-stack-sans-serif-v3
+$root-font-family: "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Droid Sans", "Ubuntu", "Helvetica Neue", Helvetica, Arial, sans-serif, "Apple Color Emoji","Segoe UI Emoji", "Segoe UI Symbol";
+
+// poole's variables
+$root-font-size: 17px;
+$root-font-weight: 400;
+// golden ratio https://grtcalculator.com
+// 18px @ 33 px, 20px @ 33 px ~ 1.667em
+$root-line-height: 1.667em;
+
+$body-color: $gray-8;
+$body-bg: #fff;
+
+$border-color: #e5e5e5;
+
+$large-breakpoint: 38em;
+$large-font-size: 19px;
+$font-scale-dot7: .7rem;
+$font-scale-dot8: .8rem;
+//
+
+// hyde-hyde
+$small-device-font-size: $root-font-size;
+$large-device-font-size: $large-font-size;
+
+// https://www.client9.com/css-system-font-stack-monospace-v2
+$code-font-family: "SFMono-Regular", "SF-Mono", Menlo, Monaco, Consolas, "Liberation Mono", "Roboto Mono", "Ubuntu Mono", "Courier New", Courier, monospace;
+$code-font-size: .9rem;
+$code-fence-font-size: .8rem;
+//$code-color: #bf616a;
+//$code-background-color: #f9f2f4;
+$code-line-height: 1.4;
+
+// links
+$link-color: $blue;
+$link-hover-color: $body-color;
+
+// section
+$section__title-font-size: 2.15rem;
+
+// post
+$post__subtitle-font-size: 1.5rem;
+$gradient-color-1: #ff2c2c;
+$gradient-color-2: #7a5e91;
+
+// post meta
+$meta-font-size: $font-scale-dot8;
+$meta-font-weight: 300;
+$meta-color: $gray-6;
+
+// post tags
+$tag-background-color: $gray-2;
+$tag-color: #606570;
+$tag-font-size: .667rem;
+
+// list of posts
+$item__date-color: #9a9a9a;
+$item__date-font-size: 1rem;
+$item__title-big-font-size: 1.52rem;
+
+// heading
+$heading-font-weight: 400;
+$h1-font-size: 2.15rem;
+$h1-line-height: 1.25;
+$h2-font-size: 1.85rem;
+$h3-font-size: 1.5rem;
+$h4-font-size:1.3rem;
+$h5-font-size:1rem;
+
+
+// sidebar
+$sidebar-color: #300030;
+$sidebar-width: 16rem;
+$site__title-font-size: 2.5rem;
+$copyright-font-size: $font-scale-dot7;
+
+// content
+$content-max-width: 38rem; // @ ~70 CPL
+$content-margin-left: $sidebar-width + 2rem;
+$content-margin-right: 2rem;
+
+// navigation
+$navigation-color: #c2255c;
+
+// portfolio
+$project__title-font-size: $h2-font-size;
+$project__subtitle-font-size-big: $h3-font-size;
+$project__subtitle-font-size-small: $h4-font-size;
+$project__subtitle-font-style: italic;
+$project__subtitle-color: #778492;
+$ribbon-color: #276582;
+$ribbon-background-color: #479fc8;

--- a/config.toml
+++ b/config.toml
@@ -5,9 +5,7 @@ languageCode = "en"
 title = "tatusl.dev"
 theme = "hyde-hyde"
 
-summarylength = 5
-
-paginate = 5
+paginate = 10
 
 ## Site Settings
 [params]

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,0 +1,36 @@
+{{ define "header" }}
+  {{ partial "header.html" . }}
+{{ end }}
+
+{{ define "content" }}
+  <div class="post-list">
+    {{ $paginator := .Paginate (where .Site.RegularPages "Type" "in" site.Params.mainSections) }}
+    {{ range $paginator.Pages }}
+      {{ if .Draft }}
+        {{ .Scratch.Set "draftPage" true }}
+      {{ else }}
+        {{ .Scratch.Set "draftPage" false }}
+      {{ end }}
+      <div class="post-list__item">
+        <span class="item__title--big">
+          <a href="{{ .RelPermalink }}" {{if .Scratch.Get "draftPage" }}class="draft"{{end}}>{{ .Title }}</a>
+        </span>
+        <span class="item__date">
+          {{ .Date.Format (.Site.Params.dateformat | default "Jan 02, 2006") }}
+        </span>
+        <span {{if .Scratch.Get "draftPage" }}class="draft"{{end}}>
+        </span>
+        </div>
+        {{ .Scratch.Delete "draftPage" }}
+     {{ end }}
+  </div>
+  {{ partial "pagination.html" . }}
+{{ end }}
+
+{{ define "footer" }}
+  {{ if .Site.GoogleAnalytics }}
+    <!-- Google Analytics -->
+    {{ template "_internal/google_analytics_async.html" . }}
+  {{ end }}
+  {{ partial "footer/font-awesome-js.html" . }}
+{{ end }}

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,0 +1,3 @@
+.item__title--big {
+    font-size: 3rem;
+}


### PR DESCRIPTION
Overrides certain `hyde-hyde` theme layouts and styles to simplify post list at the main page.

Override is done using Hugo's lookup order (https://gohugo.io/templates/lookup-order/)

### Before

![Screenshot 2020-11-28 at 13 51 28](https://user-images.githubusercontent.com/4104485/100514871-d2f86080-3180-11eb-94f9-a09e4c9636b1.png)

### After

![Screenshot 2020-11-28 at 13 56 45](https://user-images.githubusercontent.com/4104485/100514969-8eb99000-3181-11eb-9918-e6c288d2ca11.png)